### PR TITLE
Retrieve ses notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,9 @@
 // Func: Lambda handler
 exports.handler = (event, context, callback) => {
+  // Amazon SES passes information to the Lambda function in JSON format
+  // This format is described in 
+  // http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html 
+  var sesNotification = event.Records[0].ses;
+  console.log("SES Notification:\n", JSON.stringify(sesNotification, null, 2));
+  callback(null, null);
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// Func: Lambda handler
+exports.handler = (event, context, callback) => {
+};


### PR DESCRIPTION
## Overview
Retrieve ses notification. 
Amazon SES passes information to the Lambda function in JSON format.
This data contains email info received by Amazon SES exclude email content(raw data).
The format is described in http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-contents.html  
